### PR TITLE
Feat: Add checkboxes to control download of transcript and comments

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,18 +291,20 @@ def main() -> None:
             with tempfile.TemporaryDirectory() as tmpdir_str:
                 tmpdir = Path(tmpdir_str)
 
-                comments = []
                 if download_comments:
                     with st.spinner("Téléchargement des commentaires..."):
                         comments = fetch_comments(url, tmpdir)
+                else:
+                    comments = []
 
-                transcript = ""
-                actual_lang = ""
                 if download_transcript:
                     with st.spinner("Téléchargement de la transcription..."):
                         actual_lang, transcript = fetch_transcript(
                             url, tmpdir, lang
                         )
+                else:
+                    transcript = ""
+                    actual_lang = ""
 
                 st.success("Récupération terminée !")
 

--- a/app.py
+++ b/app.py
@@ -266,60 +266,86 @@ def main() -> None:
             index=0,
             help="Choisissez la langue à privilégier pour les sous‑titres."
         )
+        download_transcript = st.checkbox(
+            "Télécharger la transcription",
+            value=True,
+            help="Inclure la transcription dans le résultat."
+        )
+        download_comments = st.checkbox(
+            "Télécharger les commentaires",
+            value=True,
+            help="Inclure les commentaires dans le résultat."
+        )
         submitted = st.form_submit_button("Récupérer")
 
     if submitted:
         if not url:
             st.error("Merci de fournir une URL valide.")
             return
+        if not download_transcript and not download_comments:
+            st.error(
+                "Veuillez sélectionner au moins une option de téléchargement."
+            )
+            return
         try:
             with tempfile.TemporaryDirectory() as tmpdir_str:
                 tmpdir = Path(tmpdir_str)
-                with st.spinner("Téléchargement des commentaires..."):
-                    comments = fetch_comments(url, tmpdir)
-                with st.spinner("Téléchargement de la transcription..."):
-                    actual_lang, transcript = fetch_transcript(url, tmpdir, lang)
+
+                comments = []
+                if download_comments:
+                    with st.spinner("Téléchargement des commentaires..."):
+                        comments = fetch_comments(url, tmpdir)
+
+                transcript = ""
+                actual_lang = ""
+                if download_transcript:
+                    with st.spinner("Téléchargement de la transcription..."):
+                        actual_lang, transcript = fetch_transcript(
+                            url, tmpdir, lang
+                        )
 
                 st.success("Récupération terminée !")
 
                 # Display transcript
-                if transcript:
-                    st.subheader(f"Transcription ({actual_lang})")
-                    st.text_area(
-                        "Texte du transcript",
-                        value=transcript,
-                        height=300,
-                    )
-                    st.download_button(
-                        label="Télécharger la transcription",
-                        data=transcript,
-                        file_name=f"{actual_lang}_transcript.txt",
-                        mime="text/plain",
-                    )
-                else:
-                    st.warning("Aucune transcription n'a été trouvée pour cette vidéo.")
+                if download_transcript:
+                    if transcript:
+                        st.subheader(f"Transcription ({actual_lang})")
+                        st.text_area(
+                            "Texte du transcript",
+                            value=transcript,
+                            height=300,
+                        )
+                        st.download_button(
+                            label="Télécharger la transcription",
+                            data=transcript,
+                            file_name=f"{actual_lang}_transcript.txt",
+                            mime="text/plain",
+                        )
+                    else:
+                        st.warning("Aucune transcription n'a été trouvée pour cette vidéo.")
 
                 # Display comments
-                if comments:
-                    st.subheader(f"Commentaires ({len(comments)})")
-                    # Show a sample of the first 100 comments to avoid overloading
-                    max_display = 100
-                    for idx, comment in enumerate(comments[:max_display], start=1):
-                        st.markdown(f"**Commentaire {idx} :** {comment}")
-                    if len(comments) > max_display:
-                        st.info(
-                            f"{len(comments) - max_display} autres commentaires non affichés."
+                if download_comments:
+                    if comments:
+                        st.subheader(f"Commentaires ({len(comments)})")
+                        # Show a sample of the first 100 comments to avoid overloading
+                        max_display = 100
+                        for idx, comment in enumerate(comments[:max_display], start=1):
+                            st.markdown(f"**Commentaire {idx} :** {comment}")
+                        if len(comments) > max_display:
+                            st.info(
+                                f"{len(comments) - max_display} autres commentaires non affichés."
+                            )
+                        # Prepare comments for download
+                        comments_text = "\n".join(comments)
+                        st.download_button(
+                            label="Télécharger les commentaires",
+                            data=comments_text,
+                            file_name="comments.txt",
+                            mime="text/plain",
                         )
-                    # Prepare comments for download
-                    comments_text = "\n".join(comments)
-                    st.download_button(
-                        label="Télécharger les commentaires",
-                        data=comments_text,
-                        file_name="comments.txt",
-                        mime="text/plain",
-                    )
-                else:
-                    st.warning("Aucun commentaire n'a pu être récupéré pour cette vidéo.")
+                    else:
+                        st.warning("Aucun commentaire n'a pu être récupéré pour cette vidéo.")
         except Exception as exc:
             st.error(f"Une erreur est survenue : {exc}")
 

--- a/jules-scratch/verification/verify_checkboxes.py
+++ b/jules-scratch/verification/verify_checkboxes.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        try:
+            # Navigate to the Streamlit app
+            page.goto("http://localhost:8501", timeout=60000)
+
+            # Wait for the app to load
+            expect(page.get_by_text("Récupération de transcript et commentaires YouTube")).to_be_visible()
+
+            # Input a YouTube URL
+            page.get_by_placeholder("https://www.youtube.com/watch?v=...").fill("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+            # Uncheck the transcript download checkbox
+            transcript_checkbox = page.get_by_text("Télécharger la transcription")
+            transcript_checkbox.uncheck()
+
+            # Click the "Récupérer" button
+            page.get_by_role("button", name="Récupérer").click()
+
+            # Wait for the results to load, with a longer timeout
+            expect(page.get_by_text("Récupération terminée !")).to_be_visible(timeout=120000)
+
+            # Take a screenshot
+            page.screenshot(path="jules-scratch/verification/verification.png")
+
+        finally:
+            browser.close()
+
+if __name__ == "__main__":
+    run_verification()


### PR DESCRIPTION
This commit introduces two new checkboxes to the Streamlit UI, allowing users to selectively enable or disable the download of video transcripts and comments.

- Added `st.checkbox` for "Télécharger la transcription" and "Télécharger les commentaires", both enabled by default.
- Modified the main application logic to conditionally fetch and display the transcript and comments based on the state of these checkboxes.
- Added a validation check to ensure at least one download option is selected before the user can proceed.