### PR TITLE
Update renovate.json to automerge non-major dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "automerge": true
     },
     {
-      "comment": "Désactiver la fusion automatique pour les mises à jour majeures afin qu'elles soient examinées manuellement",
+      "comment": "Disable automerge for major updates so they are manually reviewed",
       "matchUpdateTypes": ["major"],
       "automerge": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitTypeAll(chore)",
+    ":automergeRequireAllStatusChecks"
   ],
   "packageRules": [
     {
+      "comment": "Regrouper et fusionner automatiquement les mises à jour mineures et les patchs",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major dependencies",
-      "groupSlug": "all-non-major"
+      "groupSlug": "all-non-major",
+      "automerge": true
+    },
+    {
+      "comment": "Désactiver la fusion automatique pour les mises à jour majeures afin qu'elles soient examinées manuellement",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ],
   "timezone": "Europe/Paris",

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   ],
   "packageRules": [
     {
-      "comment": "Regrouper et fusionner automatiquement les mises à jour mineures et les patchs",
+      "comment": "Automatically group and merge minor and patch updates",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-non-major",


### PR DESCRIPTION
This change updates the renovate.json configuration to:
- Automerge minor, patch, pin, and digest updates.
- Disable automerging for major updates.
- Use semantic commit messages for all updates.
- Require all status checks to pass before automerging.
- Run on weekends (Saturday and Sunday).