### PR TITLE
Fix: Correct invalid 'comment' option in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,14 +7,14 @@
   ],
   "packageRules": [
     {
-      "comment": "Automatically group and merge minor and patch updates",
+      "description": "Automatically group and merge minor and patch updates",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-non-major",
       "automerge": true
     },
     {
-      "comment": "Disable automerge for major updates so they are manually reviewed",
+      "description": "Disable automerge for major updates so they are manually reviewed",
       "matchUpdateTypes": ["major"],
       "automerge": false
     }


### PR DESCRIPTION
The 'comment' key is not a valid property within 'packageRules' in the renovate.json schema. This was causing configuration validation to fail.

Replaced 'comment' with the correct key, 'description', to resolve the schema validation error.