### PR TITLE
Feat: Move download buttons above content

### DIFF
--- a/app.py
+++ b/app.py
@@ -312,16 +312,16 @@ def main() -> None:
                 if download_transcript:
                     if transcript:
                         st.subheader(f"Transcription ({actual_lang})")
-                        st.text_area(
-                            "Texte du transcript",
-                            value=transcript,
-                            height=300,
-                        )
                         st.download_button(
                             label="Télécharger la transcription",
                             data=transcript,
                             file_name=f"{actual_lang}_transcript.txt",
                             mime="text/plain",
+                        )
+                        st.text_area(
+                            "Texte du transcript",
+                            value=transcript,
+                            height=300,
                         )
                     else:
                         st.warning("Aucune transcription n'a été trouvée pour cette vidéo.")
@@ -330,14 +330,6 @@ def main() -> None:
                 if download_comments:
                     if comments:
                         st.subheader(f"Commentaires ({len(comments)})")
-                        # Show a sample of the first 100 comments to avoid overloading
-                        max_display = 100
-                        for idx, comment in enumerate(comments[:max_display], start=1):
-                            st.markdown(f"**Commentaire {idx} :** {comment}")
-                        if len(comments) > max_display:
-                            st.info(
-                                f"{len(comments) - max_display} autres commentaires non affichés."
-                            )
                         # Prepare comments for download
                         comments_text = "\n".join(comments)
                         st.download_button(
@@ -346,6 +338,14 @@ def main() -> None:
                             file_name="comments.txt",
                             mime="text/plain",
                         )
+                        # Show a sample of the first 100 comments to avoid overloading
+                        max_display = 100
+                        for idx, comment in enumerate(comments[:max_display], start=1):
+                            st.markdown(f"**Commentaire {idx} :** {comment}")
+                        if len(comments) > max_display:
+                            st.info(
+                                f"{len(comments) - max_display} autres commentaires non affichés."
+                            )
                     else:
                         st.warning("Aucun commentaire n'a pu être récupéré pour cette vidéo.")
         except Exception as exc:

--- a/jules-scratch/verification/verify_feature_x.py
+++ b/jules-scratch/verification/verify_feature_x.py
@@ -1,0 +1,58 @@
+from playwright.sync_api import sync_playwright, expect
+import re
+
+def main():
+    """
+    This script verifies that the download buttons for the transcript and
+    comments are located above their respective content areas.
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # 1. Arrange: Go to the Streamlit app URL.
+        page.goto("http://localhost:8501")
+
+        # 2. Act: Fill in a YouTube URL and submit the form.
+        # Using a video with a small number of comments to avoid timeouts.
+        youtube_url_input = page.get_by_placeholder("https://www.youtube.com/watch?v=...")
+        expect(youtube_url_input).to_be_visible()
+        youtube_url_input.fill("https://www.youtube.com/watch?v=yv441E-i4_w")
+
+        submit_button = page.get_by_role("button", name=re.compile("Récupérer", re.IGNORECASE))
+        submit_button.click()
+
+        # 3. Assert: Check for transcript and comments, then verify button positions.
+
+        # Wait for the success message to ensure content is loaded.
+        expect(page.get_by_text("Récupération terminée !")).to_be_visible(timeout=120000)
+
+        # Ensure no "transcript not found" warning is present
+        expect(page.get_by_text("Aucune transcription n'a été trouvée")).not_to_be_visible()
+
+        # Verify transcript section using a more specific locator
+        transcript_header = page.get_by_role("heading", name=re.compile("Transcription", re.IGNORECASE))
+        expect(transcript_header).to_be_visible()
+
+        download_transcript_button = page.get_by_role("button", name="Télécharger la transcription")
+        expect(download_transcript_button).to_be_visible()
+
+        transcript_text_area = page.locator('textarea[aria-label="Texte du transcript"]')
+        expect(transcript_text_area).to_be_visible()
+
+        # Verify comments section using a more specific locator
+        comments_header = page.get_by_role("heading", name=re.compile("Commentaires", re.IGNORECASE))
+        expect(comments_header).to_be_visible()
+
+        download_comments_button = page.get_by_role("button", name="Télécharger les commentaires")
+        expect(download_comments_button).to_be_visible()
+
+        # 4. Screenshot: Capture the final result for visual verification.
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+        print("Verification script finished successfully and screenshot created.")
+
+        browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/streamlit.log
+++ b/streamlit.log
@@ -1,0 +1,2 @@
+
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.


### PR DESCRIPTION
This commit moves the download buttons for the transcript and comments to be above their respective content areas. This improves the user experience by making the download action more prominent and accessible before the user scrolls through the content.