### PR TITLE
feat: Display video metadata in UI

### DIFF
--- a/streamlit.log
+++ b/streamlit.log
@@ -1,9 +1,0 @@
-
-Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
-
-
-  You can now view your Streamlit app in your browser.
-
-  Local URL: http://localhost:8501
-  Network URL: http://192.168.0.2:8501
-  External URL: http://34.46.237.233:8501


### PR DESCRIPTION
Added video metadata extraction using yt-dlp. Displayed metadata (FPS, Resolution, Duration, View Count, Upload Date, File Size, Codec) in an expander below the URL input. Replaced subprocess-based language detection with integrated metadata fetching.

---
*PR created automatically by Jules for task [7072114789347133300](https://jules.google.com/task/7072114789347133300) started by @azman0101*